### PR TITLE
Add WTForms to requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setup(
     include_package_data=True,
     platforms='any',
     install_requires=[
-        'Flask>=0.8'
+        'Flask>=0.8',
+        'WTForms>=0.4'
     ],
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
`wtforms.fields.HiddenField` is needed for the `is_hidden_field_filter()` filter defined in `Bootstrap`. Without WTForms installed, no application using this extension will be able to start.

Version 0.4 seems to be the oldest version still available on PyPI. While newer versions should probably be used isntead, `HiddenField` exists in this version, so there is no need to force newer versions on anyone.
