### PR TITLE
Add `safe` filter on super() to avoid unexpected escape

### DIFF
--- a/flask_bootstrap/templates/bootstrap_responsive.html
+++ b/flask_bootstrap/templates/bootstrap_responsive.html
@@ -1,6 +1,6 @@
 {% extends "bootstrap_base.html" %}
 
 {% block style %}
-{{super()}}
+{{super()|safe}}
     <link href="{{'css/bootstrap-responsive.css'|bootstrap_find_resource}}" rel="stylesheet">
 {%- endblock %}


### PR DESCRIPTION
Hi mbr,

When I use `flask-bootstrap` together with [pyjade](https://github.com/syrusakbary/pyjade) I found the `style block` was escaped surprisedly. It seems safe enough to use `safe` filter on the `super()` part. How do you think?
