### PR TITLE
Point PyPI link to flask-bootstrap

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,8 +90,7 @@ Installation
 ------------
 
 Either install from github using ``pip`` or from `PyPI
-<http://pypi.python.org>`_. The package is known on PyPI as
-``flask-bootstrap``.
+<http://pypi.python.org/pypi/Flask-Bootstrap>`_.
 
 A note on versioning
 --------------------


### PR DESCRIPTION
Point the PyPI link in the readme to the PyPI page for flask-bootstrap.
This obviates the need to state what the project is known as on
PyPI, so I removed that.
