### PR TITLE
horizontal_field() to handle radio buttons (inline)

### DIFF
--- a/flask_bootstrap/templates/bootstrap_wtf.html
+++ b/flask_bootstrap/templates/bootstrap_wtf.html
@@ -8,7 +8,16 @@
 <div class="control-group {% if field.errors %}error{% endif %}">
   {{field.label(class="control-label")}}
   <div class="controls">
-    {{field(**kwargs)|safe}}
+    {% if field.type == 'RadioField' %}
+        {% for item in field %}
+            <label class="radio inline">
+                {{ item|safe }}
+                {{ item.label }}
+            </label>
+        {% endfor %}
+    {% else %}
+        {{field(**kwargs)|safe}}
+    {% endif %}
 
     {%- if field.errors %}
       {%- for error in field.errors %}


### PR DESCRIPTION
Radio button fields don't rendered correctly (or at all?).

I made this change to the project I'm working on ages ago and have just got around to creating this pull request. This commit may not be ideal as it uses the bootstrap 'inline' layout style (which is all I needed at the time), not perfect but better than the current behaviour.
