### PR TITLE
Enctype handling in quick_form macro

### DIFF
--- a/flask_bootstrap/templates/bootstrap_wtf.html
+++ b/flask_bootstrap/templates/bootstrap_wtf.html
@@ -34,8 +34,8 @@
 {%- endif %}
 {%- endmacro %}
 
-{% macro quick_form(form, action=".", method="post", class="form form-horizontal", buttons = [('submit', 'primary', 'Save')], enctype="application/x-www-form-urlencoded") %}
-<form action="{{action}}" method="{{method}}" class="{{class}}" enctype="{{enctype}}">
+{% macro quick_form(form, action=".", method="post", class="form form-horizontal", buttons = [('submit', 'primary', 'Save')], enctype=None) %}
+<form action="{{action}}" method="{{method}}" class="{{class}}"{% if enctype %} enctype="{{enctype}}"{% endif %}>
   {{ form.hidden_tag() }}
   {{ form_errors(form, 'only') }}
   {%- for field in form %}


### PR DESCRIPTION
if you have file fields in your form, you have to use
"multipart/form-data"
