### PR TITLE
Adds a footer block to base.

### DIFF
--- a/flask_bootstrap/templates/bootstrap/base.html
+++ b/flask_bootstrap/templates/bootstrap/base.html
@@ -23,6 +23,9 @@
     {% block content -%}
     {%- endblock content %}
 
+    {% block footer -%}
+    {%- endblock footer %}
+    
     {% block scripts %}
     <script src="{{bootstrap_find_resource('jquery.js', cdn='jquery')}}"></script>
     <script src="{{bootstrap_find_resource('js/bootstrap.js', cdn='bootstrap')}}"></script>


### PR DESCRIPTION
I've added a foot block to base.html

This is needed if you easily want to be able to modify all parts of your template.

I extend base.html to create my own custom layout, and without this change it is not possible to easily add a footer (or really design a custom template without completely rewriting base.html myself).

No tests should be required, though I am a bit unsure about the {% -%} syntax and what it does, I figured the footer should allow the same as the content block so I used the same syntax.
