### PR TITLE
Twitter Bootstrap is now simply "Bootstrap"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 Flask-Bootstrap
 ===============
 
-Flask-Bootstrap packages `Twitter's Bootstrap
-<http://twitter.github.com/bootstrap/>`_ into an extension that mostly consists
+Flask-Bootstrap packages `Bootstrap
+<http://getbootstrap.com>`_ into an extension that mostly consists
 of a blueprint named 'bootstrap'. It can also create links to serve Bootstrap
 from a CDN and works with no boilerplate code in your application.
 

--- a/docs/bootstrap2.rst
+++ b/docs/bootstrap2.rst
@@ -32,8 +32,8 @@ have a look at the code or sample app for major version 2, take a look at
 Flask-Bootstrap
 ^^^^^^^^^^^^^^^
 
-Flask-Bootstrap packages `Twitter's Bootstrap
-<http://twitter.github.com/bootstrap/>`_ into an extension that mostly consists
+Flask-Bootstrap packages `Bootstrap
+<http://getbootstrap.com>`_ into an extension that mostly consists
 of a blueprint named 'bootstrap'. It can also create links to serve Bootstrap
 from a CDN.
 
@@ -126,7 +126,7 @@ Either install from github using ``pip`` or from `PyPI
 A note on versioning
 ********************
 
-Flask-Bootstrap tries to keep some track of Twitter's Bootstrap releases.
+Flask-Bootstrap tries to keep some track of Bootstrap's releases.
 Versioning is usually in the form of ``Bootstrap version`` - ``Flask-Bootstrap
 iteration``. For example, a version of ``2.0.3-2`` bundles Bootstrap version
 ``2.0.3`` and is the second release of Flask-Bootstrap containing that version.

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     license='BSD',
     author='Marc Brinkmann',
     author_email='git@marcbrinkmann.de',
-    description='An extension that includes Twitter\'s Bootstrap in your '
+    description='An extension that includes Bootstrap in your '
                 'project, without any boilerplate code.',
     long_description=read('README.rst'),
     packages=['flask_bootstrap'],


### PR DESCRIPTION
See http://getbootstrap.com/about/#brand
Also updates links to point to Bootstrap's new site.
