### PR TITLE
render non-hidden fields in 'form_errors' macro

### DIFF
--- a/flask_bootstrap/templates/bootstrap/wtf.html
+++ b/flask_bootstrap/templates/bootstrap/wtf.html
@@ -2,7 +2,7 @@
   {%- if form.errors %}
     {%- for fieldname, errors in form.errors.items() %}
       {%- if bootstrap_is_hidden_field(form[fieldname]) and hiddens or
-             bootstrap_is_hidden_field(form[fieldname]) and hiddens != 'only' %}
+             not bootstrap_is_hidden_field(form[fieldname]) and hiddens != 'only' %}
         {%- for error in errors %}
           <p class="error">{{error}}</p>
         {%- endfor %}


### PR DESCRIPTION
add the missing 'not' operator in the form_errors inner condition in order to render non-hidden fields as well
