### PR TITLE
add custom class to form_errors rendering

### DIFF
--- a/flask_bootstrap/templates/bootstrap/wtf.html
+++ b/flask_bootstrap/templates/bootstrap/wtf.html
@@ -1,10 +1,10 @@
-{% macro form_errors(form, hiddens=True) %}
+{% macro form_errors(form, hiddens=True, class="error") %}
   {%- if form.errors %}
     {%- for fieldname, errors in form.errors.items() %}
       {%- if bootstrap_is_hidden_field(form[fieldname]) and hiddens or
              not bootstrap_is_hidden_field(form[fieldname]) and hiddens != 'only' %}
         {%- for error in errors %}
-          <p class="error">{{error}}</p>
+          <p class="{{class}}">{{error}}</p>
         {%- endfor %}
       {%- endif %}
     {%- endfor %}


### PR DESCRIPTION
This is useful to render the errors with bootstrap builtin classes.

For instance I'm rendering errors using:

```
<div class="has-error">
  {{ form_errors(form, hiddens=False, class="help-block") }}
</div>
```
