### PR TITLE
Make sure there is always a space between <html and the block html_attribs

### DIFF
--- a/flask_bootstrap/templates/bootstrap/base.html
+++ b/flask_bootstrap/templates/bootstrap/base.html
@@ -1,6 +1,11 @@
 {% block doc -%}
 <!DOCTYPE html>
-<html {% block html_attribs %}{% endblock html_attribs %}>
+{% if self.html_attribs() %}
+  <html {% block html_attribs %}{% endblock html_attribs %}>
+{% else %}
+  <html>
+{% endif %}
+
 {%- block html %}
   <head>
     {%- block head %}


### PR DESCRIPTION
Hi! We wanted to add lang="en" attribute, so we put it in the block but we didn't bother with adding space. Like this:

```
{% block html_attribs %}lang=en{% endblock %}
```

So the actual html tag became: <htmllang="en">. We didn't notice it for a while, so it seems like a minor issue, but it easy to fix
