### PR TITLE
Fix rendering of FileFields

### DIFF
--- a/flask_bootstrap/templates/bootstrap/wtf.html
+++ b/flask_bootstrap/templates/bootstrap/wtf.html
@@ -82,7 +82,11 @@ the necessary fix for required=False attributes, but will also not set the requi
   <div class="form-group {% if field.errors %} has-error{% endif %}">
       {%- if form_type == "inline" %}
         {{field.label(class="sr-only")|safe}}
-        {{field(class="form-control", placeholder=field.description, **kwargs)|safe}}
+        {% if field.type == 'FileField' %}
+          {{field(**kwargs)|safe}}
+        {% else %}
+          {{field(class="form-control", **kwargs)|safe}}
+        {% endif %}
       {% elif form_type == "horizontal" %}
         {{field.label(class="control-label " + (
           " col-%s-%s" % horizontal_columns[0:2]


### PR DESCRIPTION
As per the [Bootstrap docs](http://getbootstrap.com/css/#forms), only textual `<input>` elements should be given the `form-control` class. That class will cause `input` elements with `type="file"` to render incorrectly.
