### PR TITLE
Fix syntax error in html_attribs example

### DIFF
--- a/docs/basic-usage.rst
+++ b/docs/basic-usage.rst
@@ -91,7 +91,7 @@ Examples
 
 * Adding a ``lang="en"`` attribute to the ``<html>``-tag::
 
-    {% block html_attribs} lang="en"{% endblock %}
+    {% block html_attribs %} lang="en"{% endblock %}
 
 Static resources
 ----------------


### PR DESCRIPTION
Just a small fix
