### PR TITLE
Fix rendering of FileFields when form_type is 'horizontal'.

### DIFF
--- a/flask_bootstrap/templates/bootstrap/wtf.html
+++ b/flask_bootstrap/templates/bootstrap/wtf.html
@@ -92,7 +92,11 @@ the necessary fix for required=False attributes, but will also not set the requi
           " col-%s-%s" % horizontal_columns[0:2]
         ))|safe}}
         <div class=" col-{{horizontal_columns[0]}}-{{horizontal_columns[2]}}">
-          {{field(class="form-control", **kwargs)|safe}}
+          {% if field.type == 'FileField' %}
+            {{field(**kwargs)|safe}}
+          {% else %}
+            {{field(class="form-control", **kwargs)|safe}}
+          {% endif %}
         </div>
         {%- if field.errors %}
           {%- for error in field.errors %}


### PR DESCRIPTION
As https://github.com/mbr/flask-bootstrap/pull/76. Fix it when form_type is 'horizontal'.
