### PR TITLE
Show field label when rendering RadioField

### DIFF
--- a/flask_bootstrap/templates/bootstrap/wtf.html
+++ b/flask_bootstrap/templates/bootstrap/wtf.html
@@ -55,9 +55,7 @@ the necessary fix for required=False attributes, but will also not set the requi
       {{field.label(class="control-label")|safe}}
       {% for item in field -%}
         <div class="radio">
-        	<label>
         	{{item|safe}} {{item.label.text|safe}}
-        	</label>
         </div>
       {% endfor %}
     </div>


### PR DESCRIPTION
Currently, the form_field macro shows the label for each RadioField item, but
not for the RadioField itself. This fix keeps similar formatting as the other
fields, while keeping the unique structure required for RadioFields.
