### PR TITLE
add subdomain support when using local serving

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -15,6 +15,7 @@ Option                                 Default
 ====================================== ======================================================== ===
 ``BOOTSTRAP_USE_MINIFIED``             ``True``                                                 Whether or not to use the minified versions of the css/js files.
 ``BOOTSTRAP_SERVE_LOCAL``              ``False``                                                If ``True``, Bootstrap resources will be served from the local app instance every time. See :doc:`cdn` for details.
+``BOOTSTRAP_LOCAL_SUBDOMAIN``          ``None``                                                 If ``BOOTSTRAP_SERVE_LOCAL`` is ``True`` and this is not ``None``,  all assets are served on the specified sub-domain (f.e. static) - flask will automatically append ``SERVER_NAME``
 ``BOOTSTRAP_CDN_FORCE _SSL``           ``True``                                                 If a CDN resource url starts with ``//``, prepend ``'https:'`` to it.
 ``BOOTSTRAP_QUERYSTRING_REVVING``      ``True``                                                 If ``True``, will append a querystring with the current version to all static resources served locally. This ensures that upon upgrading Flask-Bootstrap, these resources are refreshed.
 ====================================== ======================================================== ===

--- a/flask_bootstrap/__init__.py
+++ b/flask_bootstrap/__init__.py
@@ -124,12 +124,15 @@ class Bootstrap(object):
         app.config.setdefault('BOOTSTRAP_QUERYSTRING_REVVING', True)
         app.config.setdefault('BOOTSTRAP_SERVE_LOCAL', False)
 
+        app.config.setdefault('BOOTSTRAP_LOCAL_SUBDOMAIN', None)
+
         blueprint = Blueprint(
             'bootstrap',
             __name__,
             template_folder='templates',
             static_folder='static',
-            static_url_path=app.static_url_path + '/bootstrap')
+            static_url_path=app.static_url_path + '/bootstrap',
+            subdomain=app.config['BOOTSTRAP_LOCAL_SUBDOMAIN'])
 
         app.register_blueprint(blueprint)
 


### PR DESCRIPTION
There is no option to specify the subdomain of the bootstrap blueprint, but this is especially nice to have if you serve all your static stuff on a special subdomain f.e. with varnish caching.

This patch adds a new variable `BOOTSTRAP_LOCAL_SUBDOMAIN`, which is directly passed to the subdomain parameter of the blueprint. It defaults to None, so there is no behavior change if unset.