### PR TITLE
Adds 'call' block support to quick_form.

### DIFF
--- a/flask_bootstrap/templates/bootstrap/wtf.html
+++ b/flask_bootstrap/templates/bootstrap/wtf.html
@@ -162,6 +162,8 @@ the necessary fix for required=False attributes, but will also not set the requi
                     button_map=button_map) }}
     {%- endif %}
   {%- endfor %}
-
+  {%- if caller -%}
+  {{ caller() }}
+  {%- endif %}
 </form>
 {%- endmacro %}


### PR DESCRIPTION
Make quick_form more flexible. Now it possible to add extra content to form with call block:

    {% call wtf.quick_form(form) %}
        ...
    {% endcall %}

For example, this change allows to have controls which are not defined in the form class.