### PR TITLE
Enable the User-ID feature in google analytics

### DIFF
--- a/flask_bootstrap/templates/bootstrap/google.html
+++ b/flask_bootstrap/templates/bootstrap/google.html
@@ -23,3 +23,17 @@
   ga('send', 'pageview');
 </script>
 {% endmacro %}
+
+{% macro uanalytics_uid(id, domain, user_id) %}
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', '{{id|safe}}', '{{domain|safe}}');
+  ga('send', 'pageview');
+  ga('set', '&uid', '{{user_id}}'); // Set the user ID using signed-in user_id.
+</script>
+{% endmacro %}
+


### PR DESCRIPTION
Copied the ```uanalytics``` macro to support Tracking Info -> User-ID feature in google analytics.
![screenshot from 2015-03-24 20 32 19](https://cloud.githubusercontent.com/assets/1077633/6804701/20b5a57a-d265-11e4-83a7-b486cafe7c05.png)
