### PR TITLE
Fix rendering of FileFields when form_type is 'basic'.

### DIFF
--- a/flask_bootstrap/templates/bootstrap/wtf.html
+++ b/flask_bootstrap/templates/bootstrap/wtf.html
@@ -113,7 +113,11 @@ the necessary fix for required=False attributes, but will also not set the requi
         {%- endif %}
       {%- else -%}
         {{field.label(class="control-label")|safe}}
-        {{field(class="form-control", **kwargs)|safe}}
+        {% if field.type == 'FileField' %}
+          {{field(**kwargs)|safe}}
+        {% else %}
+          {{field(class="form-control", **kwargs)|safe}}
+        {% endif %}
 
         {%- if field.errors %}
           {%- for error in field.errors %}


### PR DESCRIPTION
As #78.