### PR TITLE
Update nav.rst

### DIFF
--- a/docs/nav.rst
+++ b/docs/nav.rst
@@ -24,7 +24,7 @@ generate a working navbar would be:
 
     nav = Nav()
 
-    @nav.navigation
+    @nav.navigation('mynavbar')
     def mynavbar():
         return Navbar(
             'mysite',


### PR DESCRIPTION
I don't know if it was always this way, but as of the current version of Flask-Nav, you actually need to call the decorator with the ID of your nav element, as you want it to be registered on the `nav` context global. A tiny thing really, but this minor detail tripped me up at first.