### PR TITLE
Add more block flexibility to base.html

### DIFF
--- a/flask_bootstrap/templates/bootstrap/base.html
+++ b/flask_bootstrap/templates/bootstrap/base.html
@@ -6,28 +6,51 @@
     {%- block head %}
     <title>{% block title %}{% endblock title %}</title>
 
-    {%- block metas %}
+    {%- block outer_metas %}
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    {%- block metas %}
     {%- endblock metas %}
+    {%- endblock outer_metas %}
 
-    {%- block styles %}
+    {%- block outer_styles %}
     <!-- Bootstrap -->
     <link href="{{bootstrap_find_resource('css/bootstrap.css', cdn='bootstrap')}}" rel="stylesheet">
+    {%- block styles %}
     {%- endblock styles %}
+    {%- endblock outer_styles %}
     {%- endblock head %}
   </head>
   <body{% block body_attribs %}{% endblock body_attribs %}>
+    {% block outer_body -%}
+    {%- block before_body -%}
+    {%- endblock before_body -%}
     {% block body -%}
+    {% block outer_navbar -%}
+    {%- block before_navbar -%}
+    {%- endblock before_navbar -%}
     {% block navbar %}
     {%- endblock navbar %}
+    {%- block after_navbar -%}
+    {%- endblock after_navbar -%}
+    {%- endblock outer_navbar -%}
+    {% block outer_content -%}
+    {%- block before_content -%}
+    {%- endblock before_content -%}
     {% block content -%}
     {%- endblock content %}
-
-    {% block scripts %}
+    {%- block after_content -%}
+    {%- endblock after_content -%}
+    {%- endblock outer_content -%}
+    {% block outer_scripts -%}
     <script src="{{bootstrap_find_resource('jquery.js', cdn='jquery')}}"></script>
     <script src="{{bootstrap_find_resource('js/bootstrap.js', cdn='bootstrap')}}"></script>
+    {% block scripts %}
     {%- endblock scripts %}
+    {%- endblock outer_scripts -%}
     {%- endblock body %}
+    {%- block after_body -%}
+    {%- endblock after_body -%}
+    {%- endblock outer_body -%}
   </body>
 {%- endblock html %}
 </html>


### PR DESCRIPTION
Forgive me if I've overlooked a simpler way to do this, but I was looking for a good way to inject my own wrapper divs into my template (inheriting bootstrap/base.html) and ended up making these changes to allow it. This PR would allow a user's base template to do things like this:

```
{% block before_content %}
{# render pagination #}
{% endblock before_content %}

{% block outer_content %}
<div class="container container-content">
  {{super()}}
</div>
{% endblock %}

{% block outer_body %}
<div class="container container-body">
  {{super()}}
</div>
{% endblock %}

{% block scripts %}
<script>
// Now I can use the intuitive "scripts" block without nuking the core scripts.
</script>
{% endblock scripts %}
```

I realize that some of this flexibility can be achieved by careful use of super(), but I prefer not to feel so forced to use it in my page templates. In any case, this is a very useful little extension, and I thank you for it! :)