### PR TITLE
Corrected the comments in sample_app/__init__.py

### DIFF
--- a/sample_app/__init__.py
+++ b/sample_app/__init__.py
@@ -5,8 +5,7 @@
 #
 #   $ pip install -r sample_app/requirements.txt
 #
-# This will, among other things, install Flask-Appconfig, which contains a
-# program to run the application.
+# Then, you can actually run the application.
 #
 #   $ flask --app=sample_app dev
 #

--- a/sample_app/__init__.py
+++ b/sample_app/__init__.py
@@ -8,7 +8,7 @@
 # This will, among other things, install Flask-Appconfig, which contains a
 # program to run the application.
 #
-#   $ flaskdev sample_app
+#   $ flask --app=sample_app dev
 #
 # Afterwards, point your browser to http://localhost:5000, then check out the
 # source.


### PR DESCRIPTION
"flaskdev" has been deprecated in favor of the 'flask' utility. I think we should give NEW users the right way to run the sample_app. 