### PR TITLE
Force latest rendering mode for IE

### DIFF
--- a/flask_bootstrap/templates/bootstrap/base.html
+++ b/flask_bootstrap/templates/bootstrap/base.html
@@ -4,11 +4,14 @@
 {%- block html %}
   <head>
     {%- block head %}
-    <title>{% block title %}{% endblock title %}</title>
-
     {%- block metas %}
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
     {%- endblock metas %}
+
+    <title>{% block title %}{% endblock title %}</title>
 
     {%- block styles %}
     <!-- Bootstrap -->


### PR DESCRIPTION
See http://getbootstrap.com/getting-started/#support-ie-compatibility-modes
and http://getbootstrap.com/getting-started/#template

According to bootstrap documentation the 3 meta tags *must* come first
in the head.