### PR TITLE
Update forms.py

### DIFF
--- a/flask_bootstrap/forms.py
+++ b/flask_bootstrap/forms.py
@@ -48,7 +48,7 @@ class WTFormsRenderer(Visitor):
                        classes=['form-control'], **kwargs):
         wrap = self._get_wrap(node)
         wrap.add(tags.label(node.label.text, _for=node.id))
-        wrap.add(tags.input(type=type, _class=' '.join(classes), **kwargs))
+        wrap.add(tags.input(type=type, _class=' '.join(classes), name=node.name, **kwargs))
 
         return wrap
 


### PR DESCRIPTION
Wrapped inputs get rendered without name and so the form object does not work correctly. I'm not sure what is the correct fix for this, this looks to me more as a quickfix as probably more node's attributes should be put there. Or, why not just use the node render itself?
Even the sample app's example form does not work because of this.