### PR TITLE
Quick_form(): Add support for custom attributes in form tags.

### DIFF
--- a/docs/forms.rst
+++ b/docs/forms.rst
@@ -37,7 +37,8 @@ Form macro reference
                     horizontal_columns=('lg', 2, 10),\
                     enctype=None,\
                     button_map={},\
-                    id="")
+                    id="",\
+                    render_kw={})
 
    Outputs Bootstrap-markup for a complete Flask-WTF_ form.
 
@@ -58,6 +59,8 @@ Form macro reference
                       in the ``button_map`` will use the ``default`` type of
                       button.
    :param id: The ``<form>`` id attribute.
+   :param render_kw: A dictionary, specifying custom attributes for the
+                     ``<form>`` tag.
 
 .. py:function:: form_errors(form, hiddens=True)
 

--- a/flask_bootstrap/templates/bootstrap/wtf.html
+++ b/flask_bootstrap/templates/bootstrap/wtf.html
@@ -146,7 +146,8 @@ the necessary fix for required=False attributes, but will also not set the requi
                     enctype=None,
                     button_map={},
                     id="",
-                    novalidate=False) %}
+                    novalidate=False,
+                    render_kw={}) %}
 {#-
 action="" is what we want, from http://www.ietf.org/rfc/rfc2396.txt:
 
@@ -196,6 +197,7 @@ action="" is what we want, from http://www.ietf.org/rfc/rfc2396.txt:
   {%- if _enctype[0] %} enctype="{{_enctype[0]}}"{% endif -%}
   {%- if role %} role="{{role}}"{% endif -%}
   {%- if novalidate %} novalidate{% endif -%}
+  {%- if render_kw %} {{render_kw|xmlattr}}{% endif -%}
   >
   {{ form.hidden_tag() }}
   {{ form_errors(form, hiddens='only') }}


### PR DESCRIPTION
Hi,

This patch enables to specify custom attributes (as key:value pairs of a dict) for the "form" tag, when using quick_form().

The new function parameter is called "render_kw" because it serves the same purpose of the "render_kw" argument in WTForm fields (see http://wtforms.readthedocs.org/en/latest/fields.html).

My motivating example for the patch is an application that uses flask on server side, and angularjs on client side. In this case I need to define the `ng-submit="myFunc()"` attribute for the form tag -- and I still want to use the quick_form() awesome function ;-)
