### PR TITLE
Set "BOOTSTRAP_SERVE_LOCAL" default to "True"

### DIFF
--- a/flask_bootstrap/__init__.py
+++ b/flask_bootstrap/__init__.py
@@ -130,7 +130,7 @@ class Bootstrap(object):
         app.config.setdefault('BOOTSTRAP_CDN_FORCE_SSL', False)
 
         app.config.setdefault('BOOTSTRAP_QUERYSTRING_REVVING', True)
-        app.config.setdefault('BOOTSTRAP_SERVE_LOCAL', False)
+        app.config.setdefault('BOOTSTRAP_SERVE_LOCAL', True)
 
         app.config.setdefault('BOOTSTRAP_LOCAL_SUBDOMAIN', None)
 


### PR DESCRIPTION
Set the "BOOTSTRAP_SERVE_LOCAL" configuration value from "False" to "True", so that flask-bootstrap can keep working in offline environment.