### PR TITLE
BF: typo in url reference for javascript import

### DIFF
--- a/docs/basic-usage.rst
+++ b/docs/basic-usage.rst
@@ -81,13 +81,13 @@ Examples
     {% block styles %}
     {{super()}}
     <link rel="stylesheet"
-          href="{{url_for('.static', filename='mystyle.css')}}">
+          href="{{url_for('static', filename='mystyle.css')}}">
     {% endblock %}
 
 * Custom Javascript loaded *before* Bootstrap's javascript code::
 
     {% block scripts %}
-    <script src="{{url_for('.static', filename='myscripts.js')}}"></script>
+    <script src="{{url_for('static', filename='myscripts.js')}}"></script>
     {{super()}}
     {% endblock %}
 


### PR DESCRIPTION
Otherwise this error is thrown:
`werkzeug.routing.BuildError: Could not build url for endpoint 'main.static' with values ['filename']. Did you mean 'static' instead?`