### PR TITLE
Add support for URL section in pagination button

### DIFF
--- a/flask_bootstrap/templates/bootstrap/pagination.html
+++ b/flask_bootstrap/templates/bootstrap/pagination.html
@@ -14,7 +14,8 @@
                            next=('&raquo;')|safe,
                            size=None,
                            ellipses='…',
-                           args={}
+                           args={},
+                           section=None
                            )
 -%}
 {% with url_args = {} %}
@@ -26,13 +27,13 @@
   <ul class="pagination{% if size %} pagination-{{size}}{% endif %}"{{kwargs|xmlattr}}>
   {# prev and next are only show if a symbol has been passed. #}
   {% if prev != None -%}
-    <li{% if not pagination.has_prev %} class="disabled"{% endif %}><a href="{{_arg_url_for(endpoint, url_args, page=pagination.prev_num) if pagination.has_prev else '#'}}">{{prev}}</a></li>
+    <li{% if not pagination.has_prev %} class="disabled"{% endif %}><a href="{{_arg_url_for(endpoint, url_args, page=pagination.prev_num) if pagination.has_prev else '#'}}{% if section %}{{section}}{% endif %}">{{prev}}</a></li>
   {%- endif -%}
 
   {%- for page in pagination.iter_pages() %}
     {% if page %}
       {% if page != pagination.page %}
-        <li><a href="{{_arg_url_for(endpoint, url_args, page=page)}}">{{page}}</a></li>
+        <li><a href="{{_arg_url_for(endpoint, url_args, page=page)}}{% if section %}{{section}}{% endif %}">{{page}}</a></li>
       {% else %}
         <li class="active"><a href="#">{{page}} <span class="sr-only">(current)</span></a></li>
       {% endif %}
@@ -42,7 +43,7 @@
   {%- endfor %}
 
   {% if next != None -%}
-    <li{% if not pagination.has_next %} class="disabled"{% endif %}><a href="{{_arg_url_for(endpoint, url_args, page=pagination.next_num) if pagination.has_next else '#'}}">{{next}}</a></li>
+    <li{% if not pagination.has_next %} class="disabled"{% endif %}><a href="{{_arg_url_for(endpoint, url_args, page=pagination.next_num) if pagination.has_next else '#'}}{% if section %}{{section}}{% endif %}">{{next}}</a></li>
   {%- endif -%}
   </ul>
 </nav>


### PR DESCRIPTION
When use this macro to paginate comments on a post page, you have to scroll to comment area every time after you click the page button. It is useful to add a URL section in page button, here is a simple use case: `render_pagination(pagination, section='#comment')`.