### PR TITLE
add right option to flask-bootstrap

### DIFF
--- a/flask_bootstrap/nav.py
+++ b/flask_bootstrap/nav.py
@@ -48,10 +48,14 @@ class BootstrapRenderer(Visitor):
             id=node_id,
         ))
         bar_list = bar.add(tags.ul(_class='nav navbar-nav'))
+        bar_list_right = bar.add(tags.ul(_class='nav navbar-nav navbar-right'))
 
         for item in node.items:
-            bar_list.add(self.visit(item))
-
+            if hasattr(item, 'right'):
+                bar_list_right.add(self.visit(item))
+            else:
+                bar_list.add(self.visit(item))
+        
         return root
 
     def visit_Text(self, node):


### PR DESCRIPTION
Put flask-nav element to the right of the navbar.

Here is an exmaple:

```python
@nav.navigation()
def main_nav():
    navbar = Navbar('Blog')
    navbar.items.append(View('Home', 'main.index'))
    if current_user.is_authenticated:
        usergrp = []
        usergrp.append(current_user.email)
        if current_user.has_role('admin'):
            usergrp.append(View('Admin', 'admin.index'))
        usergrp.append(View('Logout', 'security.logout'))
        grp = Subgroup(*usergrp)
        grp.right = True #Goes on the right bar
        navbar.items.append(grp)
    return navbar
```
<img width="846" alt="schermata 2017-05-01 alle 16 49 44" src="https://cloud.githubusercontent.com/assets/8146506/25582580/56ad5768-2e8e-11e7-93bf-0ddfb2b1f6db.png">

