### PR TITLE
Adding id and name to form fields.

### DIFF
--- a/flask_bootstrap/forms.py
+++ b/flask_bootstrap/forms.py
@@ -48,7 +48,7 @@ class WTFormsRenderer(Visitor):
                        classes=['form-control'], **kwargs):
         wrap = self._get_wrap(node)
         wrap.add(tags.label(node.label.text, _for=node.id))
-        wrap.add(tags.input(type=type, _class=' '.join(classes), **kwargs))
+        wrap.add(tags.input(id=node.id, name=node.id, type=type, _class=' '.join(classes), **kwargs))
 
         return wrap
 


### PR DESCRIPTION
Currently form fields are missing id and name. On the previous line you can see the label is using the node.id, so using this in the input to match.