### PR TITLE
Fixed malformatted <span> tag in `icon` macro

### DIFF
--- a/flask_bootstrap/templates/bootstrap/utils.html
+++ b/flask_bootstrap/templates/bootstrap/utils.html
@@ -36,7 +36,7 @@
 
 
 {% macro icon(type=None, extra_classes=[]) -%}
-<span{{ ({'class': (['glyphicon', 'glyphicon-' + type] + extra_classes)|join(' ')})|xmlattr}}{{kwargs|xmlattr}}></span>
+<span>{{ ({'class': (['glyphicon', 'glyphicon-' + type] + extra_classes)|join(' ')})|xmlattr}}{{kwargs|xmlattr}}></span>
 {%- endmacro %}
 
 


### PR DESCRIPTION
Hardly even noticeable, but I discovered a very niche bug when the [browsepy](https://github.com/ergoithz/browsepy/blob/163cf1ca0d4f86640478e36af23e9b31bad3ee85/browsepy/stream.py#L268) Flask template streamer crashed whenever it would attempt to compile the following line in any template:

```
{%- import "bootstrap/utils.py" as utils -%}
``` 

I was left scratching my head trying to figure out where the root of the issue was. I took a closer look at the source for the file, noticed the malformatted span in the macro:

```
{% macro icon(type=None, extra_classes=[]) -%}
<span{{ ({'class': (['glyphicon', 'glyphicon-' + type] + extra_classes)|join(' ')})|xmlattr}}{{kwargs|xmlattr}}></span>
{%- endmacro %}
 ```

I was able to close the tag, test it out, and confirm that is _was_ the missing `>` from the tag was enough to break parser used to chunk the template into a streaming response.