### PR TITLE
Correct typo in forms.rst

### DIFF
--- a/docs/forms.rst
+++ b/docs/forms.rst
@@ -29,7 +29,7 @@ Form macro reference
 --------------------
 
 .. py:function:: quick_form(form,\
-                    action=".",\
+                    action="",\
                     method="post",\
                     extra_classes=None,\
                     role="form",\


### PR DESCRIPTION
Noticed a "." is listed as the default value for the 'action' parameter in the quick_form method, which I don't think is correct (it should be "")